### PR TITLE
Simplify locking

### DIFF
--- a/kt/lock.go
+++ b/kt/lock.go
@@ -24,14 +24,13 @@ func (c *Context) Unlock() {
 }
 
 func (c *Context) getMU(name string) *sync.RWMutex {
-	lockName := tSuite(c.T) + "/" + name
 	if c.mus == nil {
 		c.mus = make(map[string]*sync.RWMutex)
 	}
-	mu, ok := c.mus[lockName]
+	mu, ok := c.mus[name]
 	if !ok {
 		mu = &sync.RWMutex{}
-		c.mus[lockName] = mu
+		c.mus[name] = mu
 	}
 	return mu
 }

--- a/kt/name.go
+++ b/kt/name.go
@@ -3,15 +3,9 @@
 package kt
 
 import (
-	"strings"
 	"testing"
 )
 
 func tName(t *testing.T) string {
 	return t.Name()
-}
-
-func tSuite(t *testing.T) string {
-	parts := strings.SplitN(t.Name(), "/", 2)
-	return parts[0]
 }


### PR DESCRIPTION
contexts are already per-suite, so no need to add this complexity