### PR TITLE
Wrap find-related tests with Retries

### DIFF
--- a/db/createIndex.go
+++ b/db/createIndex.go
@@ -33,28 +33,30 @@ func testCreateIndex(ctx *kt.Context, client *kivik.Client) {
 	}
 	ctx.Run("group", func(ctx *kt.Context) {
 		ctx.Run("Valid", func(ctx *kt.Context) {
-			ctx.Parallel()
-			ctx.CheckError(db.CreateIndex(context.Background(), "", "", `{"fields":["foo"]}`))
+			doCreateIndex(ctx, db, `{"fields":["foo"]}`)
 		})
 		ctx.Run("NilIndex", func(ctx *kt.Context) {
-			ctx.Parallel()
-			ctx.CheckError(db.CreateIndex(context.Background(), "", "", nil))
+			doCreateIndex(ctx, db, nil)
 		})
 		ctx.Run("BlankIndex", func(ctx *kt.Context) {
-			ctx.Parallel()
-			ctx.CheckError(db.CreateIndex(context.Background(), "", "", ""))
+			doCreateIndex(ctx, db, "")
 		})
 		ctx.Run("EmptyIndex", func(ctx *kt.Context) {
-			ctx.Parallel()
-			ctx.CheckError(db.CreateIndex(context.Background(), "", "", "{}"))
+			doCreateIndex(ctx, db, "{}")
 		})
 		ctx.Run("InvalidIndex", func(ctx *kt.Context) {
-			ctx.Parallel()
-			ctx.CheckError(db.CreateIndex(context.Background(), "", "", `{"oink":true}`))
+			doCreateIndex(ctx, db, `{"oink":true}`)
 		})
 		ctx.Run("InvalidJSON", func(ctx *kt.Context) {
-			ctx.Parallel()
-			ctx.CheckError(db.CreateIndex(context.Background(), "", "", `chicken`))
+			doCreateIndex(ctx, db, `chicken`)
 		})
 	})
+}
+
+func doCreateIndex(ctx *kt.Context, db *kivik.DB, index interface{}) {
+	ctx.Parallel()
+	err := kt.Retry(func() error {
+		return db.CreateIndex(context.Background(), "", "", index)
+	})
+	ctx.CheckError(err)
 }

--- a/db/explain.go
+++ b/db/explain.go
@@ -65,7 +65,12 @@ func doExplainTest(ctx *kt.Context, client *kivik.Client, dbName string) {
 		return
 	}
 
-	plan, err := db.Explain(context.Background(), `{"selector":{"_id":{"$gt":null}}}`)
+	var plan *kivik.QueryPlan
+	err = kt.Retry(func() error {
+		var e error
+		plan, e = db.Explain(context.Background(), `{"selector":{"_id":{"$gt":null}}}`)
+		return e
+	})
 	if !ctx.IsExpectedSuccess(err) {
 		return
 	}

--- a/db/find.go
+++ b/db/find.go
@@ -94,7 +94,13 @@ func doFindTest(ctx *kt.Context, client *kivik.Client, dbName string, expOffset 
 		return
 	}
 
-	rows, err := db.Find(context.Background(), `{"selector":{"_id":{"$gt":null}}}`)
+	var rows *kivik.Rows
+	err = kt.Retry(func() error {
+		var e error
+		rows, e = db.Find(context.Background(), `{"selector":{"_id":{"$gt":null}}}`)
+		return e
+	})
+
 	if !ctx.IsExpectedSuccess(err) {
 		return
 	}

--- a/db/put.go
+++ b/db/put.go
@@ -41,9 +41,9 @@ func testPut(ctx *kt.Context, client *kivik.Client) {
 			}
 			var rev string
 			err := kt.Retry(func() error {
-				var err error
-				rev, err = db.Put(context.Background(), doc.ID, doc)
-				return err
+				var e error
+				rev, e = db.Put(context.Background(), doc.ID, doc)
+				return e
 			})
 			if !ctx.IsExpectedSuccess(err) {
 				return
@@ -51,7 +51,10 @@ func testPut(ctx *kt.Context, client *kivik.Client) {
 			doc.Rev = rev
 			doc.Age = 40
 			ctx.Run("Update", func(ctx *kt.Context) {
-				_, err = db.Put(context.Background(), doc.ID, doc)
+				err := kt.Retry(func() error {
+					_, e := db.Put(context.Background(), doc.ID, doc)
+					return e
+				})
 				ctx.CheckError(err)
 			})
 		})


### PR DESCRIPTION
Seems this is broken in Couch < 2.0