### PR TITLE
More consistent replication URL checking

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ variables:
 
 lint:
     stage: test
-    image: golangci/golangci-lint:v1.32
+    image: golangci/golangci-lint:v1.30
     services: []
     before_script:
         - ''


### PR DESCRIPTION
It seems CouchDB is inconsistent in what URL format it returns, so this
tries to compensate.